### PR TITLE
Increase routes content length limit

### DIFF
--- a/cli/node/routes.rs
+++ b/cli/node/routes.rs
@@ -232,7 +232,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         // POST /testnet3/program/deploy
         let program_deploy = warp::post()
             .and(warp::path!("testnet3" / "program" / "deploy"))
-            .and(warp::body::content_length_limit(4096))
+            .and(warp::body::content_length_limit(max_content_length))
             .and(warp::body::json())
             .and(with(self.ledger.clone()))
             .and(with(self.consensus.clone()))
@@ -240,7 +240,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
 
         let program_execute = warp::post()
             .and(warp::path!("testnet3" / "program" / "execute"))
-            .and(warp::body::content_length_limit(4096))
+            .and(warp::body::content_length_limit(max_content_length))
             .and(warp::body::json())
             .and(with(self.ledger.clone()))
             .and(with(self.consensus.clone()))

--- a/cli/node/routes.rs
+++ b/cli/node/routes.rs
@@ -224,7 +224,10 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
 
         // TODO: Faucet total.
 
-        // TODO: content length limit via input
+        // Determine Content Length based on Input Size supported by the Network.
+        let max_data_size = N::MAX_DATA_SIZE_IN_FIELDS * Field::<N>::SIZE_IN_DATA_BITS as u32;
+        let max_data_inputs = N::MAX_DATA_DEPTH * N::MAX_DATA_ENTRIES * N::MAX_INPUTS;
+        let max_content_length = (max_data_inputs as u32 * max_data_size) as u64;
 
         // POST /testnet3/program/deploy
         let program_deploy = warp::post()


### PR DESCRIPTION
Signed-off-by: Andrew Rosborough <arosborough@acgnw.com>

I tried to deploy a contract with slingshot, but the reset endpoint kept failing with 413 Payload Too Large errors because the content limit 4096 was too modest

## Motivation

To deploy a WIP program to a development node and begin developing a frontend with the rest API.

## Test Plan
Take my word for it, when I changed this code 413 errors turned into 500 errors, but at least some contracts I imported were signed and verified (e.g. successfully deployed).

The 500 error indicates that maybe the limit is too high, and the VM or OS needs its static limits increased.

before:
```
arosboro@Andrews-iMac wubby % slingshot --verbosity 3 deploy --path build -f 100                                

📦 Deploying 'utf_8_bytes16.aleo' to the local development node...

⚠️  ❌ Failed to deploy 'utf_8_bytes16.aleo' to the local development node: http://localhost:4180/testnet3/program/deploy: status code 413
```

![Screen Shot 2022-12-14 at 8 02 25 AM](https://user-images.githubusercontent.com/2224595/207602391-0e409f0a-909f-4a2c-9cd8-508236dbf618.png)

after:

```
arosboro@Andrews-iMac wubby % slingshot --verbosity 3 deploy --path build -f 50                                 

📦 Deploying 'utf_8_bytes16.aleo' to the local development node...

✅ Successfully deployed 'utf_8_bytes16.aleo' to the local development node.
📦 Deploying 'namespace.aleo' to the local development node...

⚠️  ❌ Failed to deploy 'namespace.aleo' to the local development node: http://localhost:4180/testnet3/program/deploy: status code 500
```

## Related PRs

N/A

(Link your related PRs here)
