### PR TITLE
[Feature] Requires program name during deployment.

### DIFF
--- a/cli/commands/mod.rs
+++ b/cli/commands/mod.rs
@@ -39,7 +39,7 @@ use clap::Parser;
 #[clap(
     name = "slingshot",
     author = "The Aleo Team <hello@aleo.org>",
-    about = "A lightweight CLI for deploying programs and executing transactions on Aleo.",
+    about = "A lightweight CLI for deploying programs and executing transactions on a development node.",
     setting = clap::AppSettings::ColoredHelp
 )]
 pub struct CLI {


### PR DESCRIPTION
This PR, requires a user to specify the program name when invoking `slingshot deploy`.
The deployment command now has the form `slingshot deploy foo.aleo -f 1000000`.
This PR is necessary to ensure that imported programs are deployed before their dependents. This also allows users to deploy multiple programs that depend on the same parent.
